### PR TITLE
chore: bump Truv SDK to 1.15.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'kotlin-android'
 }
 
-def truvSdkVersion = '1.14.0'
+def truvSdkVersion = '1.15.0'
 
 android {
     signingConfigs {


### PR DESCRIPTION
Point the demo app at the released `com.truv.sdk:android_sdk:1.15.0` (Maven Central). Final step of the Android 1.15.0 release (CONS-7404 / QA-1047).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Truv SDK dependency to version 1.15.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->